### PR TITLE
Update poetry installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8
 WORKDIR /app
 
 # Install Poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python && \
     cd /usr/local/bin && \
         ln -s /opt/poetry/bin/poetry && \
             poetry config virtualenvs.create false


### PR DESCRIPTION
the poetry installation URL in dockerfile had deprecated. (ref: https://github.com/python-poetry/poetry/issues/6377) 

<img width="1181" alt="스크린샷 2022-10-17 오후 10 52 10" src="https://user-images.githubusercontent.com/2231510/196195185-248c4ff7-9a31-438f-a7d4-162b78caa0b1.png">
